### PR TITLE
Исправление бага с построением reflink

### DIFF
--- a/src/ThreadImport/ChainManager.php
+++ b/src/ThreadImport/ChainManager.php
@@ -34,8 +34,6 @@ class ChainManager
         foreach ($thread->getPosts() as $post) {
             $this->recursiveInsertChain($post);
         }
-
-        $this->entityManager->flush();
     }
 
     private function recursiveInsertChain(Post $forPost, Post $reference = null, int $depth = 0): void

--- a/src/ThreadImport/ThreadImporter.php
+++ b/src/ThreadImport/ThreadImporter.php
@@ -50,6 +50,10 @@ class ThreadImporter
             }
             
             $this->entityManager->persist($thread);
+            // Save posts into database so that chainManager can 
+            // save links between them
+            $this->entityManager->flush();
+
             $this->chainManager->insertChain($thread);
             if ($onThreadImported) {
                 $onThreadImported($thread);


### PR DESCRIPTION
Проблема была в том, что при парсинге треда создавались посты, но не вставлялись в БД (не делался flush()). Напомню, на всякий случай, что persist() отдает сущность под управление Доктрины, а flush() сбрасывает все изменения и новые сущности в БД.

При вызове ChainManager он пытался сделать INSERT INTO reflink и происходила ошибка, так как постов, на которые ставилась ссылка, еще не было в БД. Раньше проблемы не было, так как ChainManager не делал INSERT, а просто создавал сущности Доктрины.

Исправил добавлением flush() перед вызовом ChainManager.

В построении цепочек все равно есть некоторый скрытый баг, связанный с ссылками между тредами. Допустим, у нас есть посты A и B из разных тредов TA и TB, и A ссылается на B. Мы запускаем переимпорт треда TB. Что происходит: 

- удаляется тред TB, пост B и ссылка A -> B
- импортируется тред TB и пост B
- ChainManager проходится по постам в треде TB и восстанавливает ссылки, идущие из постов TB. Но он не восстанавливает ссылку A -> B

В теории надо после импорта треда T делать следующее: 

- восстанавливать все ссылки, идущие из постов треда T
- восстанавливать все ссылки из более новых постов к постам треда T (то есть: выбираем все посты, новее ОП-поста T, не принадлежащие T и создаем ссылки из них к постам треда T)

Это может быть сложно, и можно поступать так: 

После импорта N тредов определяем самый старый. Выбираем все треды новее этого. И перестраиваем цепочки во всех тредах, начиная с самого старого до самого последнего.

Ну или если еще упрощать, то так: 

Если мы импортировали не самый новый тред, то сделать полную перестройку цепочек.

Надеюсь, я никого не запутал.
